### PR TITLE
fix close handler

### DIFF
--- a/Sources/SignalRClient/HttpConnection.swift
+++ b/Sources/SignalRClient/HttpConnection.swift
@@ -422,10 +422,7 @@ actor HttpConnection: ConnectionProtocol {
         // We should not call onclose again
         if connectionStartedSuccessfully {
             connectionStartedSuccessfully = false
-            Task { [weak self] () in 
-                guard let self = self else { return }
                 await self.onClose?(error)
-            }
         }
     }
 

--- a/Sources/SignalRClient/HubConnection.swift
+++ b/Sources/SignalRClient/HubConnection.swift
@@ -276,10 +276,12 @@ public actor HubConnection {
         // 3. Reconnecting: In this case, we're in the control of previous reconnect(), let that function handle the reconnection
 
         if (connectionStatus == .Connected) {
-            do {
-                try await reconnect(error: error)
-            } catch {
-                logger.log(level: .warning, message: "Connection reconnect failed: \(error)")
+            Task {
+                do {
+                    try await reconnect(error: error)
+                } catch {
+                    logger.log(level: .warning, message: "Connection reconnect failed: \(error)")
+                }
             }
         }
     }

--- a/Sources/SignalRClient/Transport/LongPollingTransport.swift
+++ b/Sources/SignalRClient/Transport/LongPollingTransport.swift
@@ -224,7 +224,7 @@ actor LongPollingTransport: Transport {
         guard let onCloseHandler = self.onCloseHandler else {
             return
         }
-
+        self.onCloseHandler = nil
         logger.log(
             level: .debug,
             message:


### PR DESCRIPTION
1. Ensure the transport calls close only once.
2. Ensure the connection is in stopped state if stop is called.