### PR TITLE
Adjust usage of httpclient and SignalRError

### DIFF
--- a/Sources/SignalRClient/SignalRError.swift
+++ b/Sources/SignalRClient/SignalRError.swift
@@ -4,7 +4,7 @@
 import Foundation
 
 // Define error types for better error handling
-public enum SignalRError: Error, Equatable {
+public enum SignalRError: Error, Equatable, CustomStringConvertible {
     case incompleteMessage
     case invalidDataType
     case failedToEncodeHandshakeRequest
@@ -33,7 +33,7 @@ public enum SignalRError: Error, Equatable {
     case streamCancelled
     case serverTimeout(TimeInterval)
 
-    var localizedDescription: String {
+    public var description: String {
         switch self {
         case .incompleteMessage:
             return "Message is incomplete."

--- a/Sources/SignalRClient/Transport/LongPollingTransport.swift
+++ b/Sources/SignalRClient/Transport/LongPollingTransport.swift
@@ -160,6 +160,9 @@ actor LongPollingTransport: Transport {
             message:
             "(LongPolling transport) request complete. Response status: \(response.statusCode)."
         )
+        if !response.ok() {
+            throw SignalRError.unexpectedResponseCode(response.statusCode)
+        }
     }
 
     func stop(error: (any Error)?) async throws {
@@ -212,8 +215,8 @@ actor LongPollingTransport: Transport {
         logger.log(
             level: .debug, message: "(LongPolling transport) Stop finished."
         )
-        
-        if(triggerClose){
+
+        if (triggerClose) {
             await raiseClose()
         }
     }


### PR DESCRIPTION
### Check HttpClient status code
Our httpclient doesn't throw when the statusCode is not in [200,300)

Changes:
1. Fix `longpolling send`  
2. Fix `negotiate` error checking

### Adjust `SignalRError`
Add `CustomStringConvertible` protocol for `SignalRError`.  So the designed error message would shown as expected.