### PR TITLE
Expose public initializer for HttpConnectionOptions

### DIFF
--- a/Sources/SignalRClient/HttpConnection.swift
+++ b/Sources/SignalRClient/HttpConnection.swift
@@ -28,6 +28,8 @@ public struct HttpConnectionOptions {
     var webSocket: AnyObject? // Placeholder for WebSocket type
     var eventSource: EventSourceAdaptor?
     var useStatefulReconnect: Bool? // Not supported yet
+    
+    public init() {}
 }
 
 // MARK: - Models


### PR DESCRIPTION
### 🔧 Summary

This PR adds a `public init()` to the `HttpConnectionOptions` struct, enabling external consumers to create and customize instances outside the module.

---

### Problem

Currently, `HttpConnectionOptions` is a `public struct` with several `public` properties, including `accessTokenFactory`. However, it lacks a public initializer, making it impossible to construct an instance from outside the module.

This prevents developers from using methods like:

```swift
HubConnectionBuilder()
    .withUrl(url: "https://example.com", options: customOptions)
```

### Related Issue
This fix is related to #65 and especially the last comment from @mikheil-natsvlishvili 
 https://github.com/dotnet/signalr-client-swift/issues/65#issuecomment-2838487727 
A full explanation of this issue can be found here #77 
